### PR TITLE
Add icon support for linux

### DIFF
--- a/shortcutter/base.py
+++ b/shortcutter/base.py
@@ -180,7 +180,7 @@ class ShortCutter(object):
                 return activate, None
 
         return None, None
- 
+     
     def _check_if_conda_root(self, path):
         """
         Checks if provided path is conda root. It should have
@@ -200,7 +200,7 @@ class ShortCutter(object):
                         return p.abspath(activate)
         return None
 
-    def create_desktop_shortcut(self, target, shortcut_name=None):
+    def create_desktop_shortcut(self, target, shortcut_name=None, icon=None):
         """
         Creates a desktop shortcut to a target.
 
@@ -213,12 +213,15 @@ class ShortCutter(object):
         shortcut_name : str=None
             Name of the shortcut without extension (``.lnk`` would be appended if needed).
             If None uses the target filename.
+        icon : str=None
+            Path to icon file
 
         Returns
         -------
         tuple (str or None, str or None, str or None)
             (shortcut_name, target_path, shortcut_file_path)
         """
+        print('create_desktop_shortcut() %s' % icon)
         if not p.isdir(self.desktop_folder):
             msg = "Desktop folder '{}' not found.".format(self.desktop_folder)
             if self.raise_errors:
@@ -227,9 +230,9 @@ class ShortCutter(object):
                 self.error_log.write(msg + '\n')
                 return None, None, None
         else:
-            return self.create_shortcut(target, self.desktop_folder, shortcut_name)
+            return self.create_shortcut(target, self.desktop_folder, shortcut_name, icon)
 
-    def create_menu_shortcut(self, target, shortcut_name=None):
+    def create_menu_shortcut(self, target, shortcut_name=None, icon=None):
         """
         Creates a menu shortcut to a target.
 
@@ -242,6 +245,8 @@ class ShortCutter(object):
         shortcut_name : str=None
             Name of the shortcut without extension (``.lnk`` would be appended if needed).
             If None uses the target filename.
+        icon : str=None
+            Path to icon file
 
         Returns
         -------
@@ -273,7 +278,7 @@ class ShortCutter(object):
         w_ascii_name = str(w_unicode_name.encode('utf-8'))[1:].strip('"').strip("'").replace('\\', '_')
         return w_ascii_name
 
-    def _create_wrapped_shortcut(self, shortcut_name, target_path, shortcut_directory, activate_args=None):
+    def _create_wrapped_shortcut(self, shortcut_name, target_path, shortcut_directory, activate_args=None, icon=None):
         """
         Creates shell script wrapper for shortcut with activation.
         
@@ -317,9 +322,9 @@ class ShortCutter(object):
             with open(wrapper_path, 'w') as f:
                 f.write(script)
                 self._make_executable(wrapper_path)
-        return self._create_shortcut_file(shortcut_name, wrapper_path, shortcut_directory)
+        return self._create_shortcut_file(shortcut_name, wrapper_path, shortcut_directory, icon)
 
-    def create_shortcut(self, target, shortcut_directory, shortcut_name=None):
+    def create_shortcut(self, target, shortcut_directory, shortcut_name=None, icon=None):
         """
         Creates a shortcut to a target.
 
@@ -340,6 +345,7 @@ class ShortCutter(object):
         tuple (str, str, str or None)
             (shortcut_name, target_path, shortcut_file_path)
         """
+        print('create_shortcut() %s' % icon)
         # Set the target path:
         target_path = self.find_target(target)
 
@@ -370,12 +376,12 @@ class ShortCutter(object):
                                                                                                            self.exists))
 
             if isdir:
-                return self._create_shortcut_to_dir(shortcut_name, target_path, shortcut_directory)
+                return self._create_shortcut_to_dir(shortcut_name, target_path, shortcut_directory, icon)
 
             elif self.activate:
                 activate, env = self.activate_args
                 if activate:
-                    return self._create_wrapped_shortcut(shortcut_name, target_path, shortcut_directory)
+                    return self._create_wrapped_shortcut(shortcut_name, target_path, shortcut_directory, icon)
 
                 elif (not activate) and env:
                     raise ShortcutError('Shortcutter failed to find conda root (or activate script there). ' +
@@ -384,9 +390,10 @@ class ShortCutter(object):
                                         'Checked `CONDA_ROOT` environment variable. ' +
                                         'Searched `conda` executable in the PATH.')
             # Use simple shortcuts if self.activate=False or we are installing to common python installation:
-            return self._create_shortcut_file(shortcut_name, target_path, shortcut_directory)
+            return self._create_shortcut_file(shortcut_name, target_path, shortcut_directory, icon)
 
         ret = self._safe_create(create)
+        print('//create_shortcut() %s' % icon)    
         return ret if (ret != 'error') else (shortcut_name, target_path, None)
 
     def _safe_create(self, create):

--- a/shortcutter/base.py
+++ b/shortcutter/base.py
@@ -153,7 +153,7 @@ class ShortCutter(object):
             #   `<conda_root>/envs/<local_root_basename>`
             ddot = p.dirname(self.local_root)
             activate = self._check_if_conda_root(p.dirname(ddot))
-            if (p.basename(ddot) == 'envs') and activate: 
+            if (p.basename(ddot) == 'envs') and activate:
                 return activate, p.basename(self.local_root)
 
             # check if we are running pip via `conda env create -f env.yaml`
@@ -180,7 +180,7 @@ class ShortCutter(object):
                 return activate, None
 
         return None, None
-     
+
     def _check_if_conda_root(self, path):
         """
         Checks if provided path is conda root. It should have
@@ -208,7 +208,7 @@ class ShortCutter(object):
         ----------
         target : str
             The target to create a shortcut for, it can be a fully qualified
-            file path ``/path/to/my_program`` or a simple application name 
+            file path ``/path/to/my_program`` or a simple application name
             ``my_program``.
         shortcut_name : str=None
             Name of the shortcut without extension (``.lnk`` would be appended if needed).
@@ -239,7 +239,7 @@ class ShortCutter(object):
         ----------
         target : str
             The target to create a shortcut for, it can be a fully qualified
-            file path ``/path/to/my_program`` or a simple application name 
+            file path ``/path/to/my_program`` or a simple application name
             ``my_program``.
         shortcut_name : str=None
             Name of the shortcut without extension (``.lnk`` would be appended if needed).
@@ -280,10 +280,10 @@ class ShortCutter(object):
     def _create_wrapped_shortcut(self, shortcut_name, target_path, shortcut_directory, activate_args=None, icon=None):
         """
         Creates shell script wrapper for shortcut with activation.
-        
+
         Providing activate_args optional argument switches to creation
         of shortcut to terminal with activated environment.
-        
+
         Returns a tuple of (shortcut_name, target_path, shortcut_file_path)
         """
         if activate_args is None:
@@ -331,7 +331,7 @@ class ShortCutter(object):
         ----------
         target : str
             The target to create a shortcut for, it can be a fully qualified
-            file path ``/path/to/my_program`` or a simple application name 
+            file path ``/path/to/my_program`` or a simple application name
             ``my_program``.
         shortcut_directory : str
             The directory path where the shortcut should be created.
@@ -434,6 +434,10 @@ class ShortCutter(object):
         bool
             True if all operations were successful, False otherwise.
         """
+        # Link shortcuts
+        global linkd
+        linkd={}
+
         activate, env = self.activate_args
         if not activate:
             return
@@ -462,6 +466,12 @@ class ShortCutter(object):
                         ret.append(self._safe_create(
                             lambda: self._create_wrapped_shortcut(name, None, path, (activate, env))
                         ))
+        
+        # link shortcuts dict: {Name: [Link target path, Path to link file]}
+        for i in ret:
+            linkd[i[0]] = [i[1],i[2]]
+        print('--- debug: linkd: %s' % linkd)
+        
         return False if ('error' in ret) else True
 
     # should be overridden
@@ -476,7 +486,7 @@ class ShortCutter(object):
         """
         Recursively creates dirs if they don't exist.
         Utilizes ``self.raise_errors`` and ``self.error_log``.
-        
+
         Parameters
         ----------
         \*args : str
@@ -504,7 +514,7 @@ class ShortCutter(object):
         ----------
         target : str
             The target to find, it can be a fully qualified
-            file path ``/path/to/my_program`` or a simple application name 
+            file path ``/path/to/my_program`` or a simple application name
             ``my_program``.
 
         Returns

--- a/shortcutter/base.py
+++ b/shortcutter/base.py
@@ -345,7 +345,7 @@ class ShortCutter(object):
         tuple (str, str, str or None)
             (shortcut_name, target_path, shortcut_file_path)
         """
-        print('create_shortcut() %s' % icon)
+        print('22:create_shortcut() %s' % icon)
         # Set the target path:
         target_path = self.find_target(target)
 
@@ -367,7 +367,7 @@ class ShortCutter(object):
             else:
                 # getting the file name and removing the extension:
                 shortcut_name = p.splitext(p.basename(target))[0]
-
+        print('44:')
         # Create shortcut function:
         def create():
             if not target_path:
@@ -376,11 +376,13 @@ class ShortCutter(object):
                                                                                                            self.exists))
 
             if isdir:
+                print('53: isdir is True')
                 return self._create_shortcut_to_dir(shortcut_name, target_path, shortcut_directory, icon)
 
             elif self.activate:
                 activate, env = self.activate_args
                 if activate:
+                    print('59:{},{},{},{}'.format(shortcut_name, target_path, shortcut_directory, icon))
                     return self._create_wrapped_shortcut(shortcut_name, target_path, shortcut_directory, icon)
 
                 elif (not activate) and env:
@@ -391,9 +393,10 @@ class ShortCutter(object):
                                         'Searched `conda` executable in the PATH.')
             # Use simple shortcuts if self.activate=False or we are installing to common python installation:
             return self._create_shortcut_file(shortcut_name, target_path, shortcut_directory, icon)
-
+        print('70:')
         ret = self._safe_create(create)
-        print('//create_shortcut() %s' % icon)    
+        print('ret: {}'.format(ret))
+        print('//73:create_shortcut() %s' % icon)    
         return ret if (ret != 'error') else (shortcut_name, target_path, None)
 
     def _safe_create(self, create):
@@ -403,6 +406,7 @@ class ShortCutter(object):
         :param create:
             function to call (without arguments)
         """
+        print('_safe_create()')
         if self.raise_errors:
             ret = create()
         else:

--- a/shortcutter/base.py
+++ b/shortcutter/base.py
@@ -221,7 +221,6 @@ class ShortCutter(object):
         tuple (str or None, str or None, str or None)
             (shortcut_name, target_path, shortcut_file_path, icon_file_path)
         """
-        print('create_desktop_shortcut() %s' % icon)
         if not p.isdir(self.desktop_folder):
             msg = "Desktop folder '{}' not found.".format(self.desktop_folder)
             if self.raise_errors:
@@ -230,7 +229,7 @@ class ShortCutter(object):
                 self.error_log.write(msg + '\n')
                 return None, None, None, None
         else:
-            return self.create_shortcut(target, self.desktop_folder, shortcut_name, icon)
+            return self.create_shortcut(target, self.desktop_folder, shortcut_name, icon=icon)
 
     def create_menu_shortcut(self, target, shortcut_name=None, icon=None):
         """
@@ -250,8 +249,8 @@ class ShortCutter(object):
 
         Returns
         -------
-        tuple (str or None, str or None, str or None)
-            (shortcut_name, target_path, shortcut_file_path)
+        tuple (str or None, str or None, str or None, str or None)
+            (shortcut_name, target_path, shortcut_file_path, icon_file_path)
         """
         if not p.isdir(self.menu_folder):
             msg = "Menu folder '{}' not found.".format(self.menu_folder)
@@ -259,9 +258,9 @@ class ShortCutter(object):
                 raise ShortcutNoMenuError(msg)
             elif self.error_log is not None:
                 self.error_log.write(msg + '\n')
-                return None, None, None
+                return None, None, None, None
         else:
-            return self.create_shortcut(target, self.menu_folder, shortcut_name)
+            return self.create_shortcut(target, self.menu_folder, shortcut_name, icon=icon)
 
     @classmethod
     def _path_to_name(cls, path):
@@ -339,13 +338,14 @@ class ShortCutter(object):
         shortcut_name : str=None
             Name of the shortcut without extension (``.lnk`` would be appended if needed).
             If None uses the target filename.
+        icon : str=None
+            File path to icon file
 
         Returns
         -------
-        tuple (str, str, str or None)
-            (shortcut_name, target_path, shortcut_file_path)
+        tuple (str, str, str or None, str or None)
+            (shortcut_name, target_path, shortcut_file_path, icon_file_path)
         """
-        print('22:create_shortcut() %s' % icon)
         # Set the target path:
         target_path = self.find_target(target)
 
@@ -367,7 +367,6 @@ class ShortCutter(object):
             else:
                 # getting the file name and removing the extension:
                 shortcut_name = p.splitext(p.basename(target))[0]
-        print('44:')
         # Create shortcut function:
         def create():
             if not target_path:
@@ -376,13 +375,11 @@ class ShortCutter(object):
                                                                                                            self.exists))
 
             if isdir:
-                print('53: isdir is True')
                 return self._create_shortcut_to_dir(shortcut_name, target_path, shortcut_directory, icon)
 
             elif self.activate:
                 activate, env = self.activate_args
                 if activate:
-                    print('59:{},{},{},{}'.format(shortcut_name, target_path, shortcut_directory, icon))
                     return self._create_wrapped_shortcut(shortcut_name, target_path, shortcut_directory, icon)
 
                 elif (not activate) and env:
@@ -393,10 +390,7 @@ class ShortCutter(object):
                                         'Searched `conda` executable in the PATH.')
             # Use simple shortcuts if self.activate=False or we are installing to common python installation:
             return self._create_shortcut_file(shortcut_name, target_path, shortcut_directory, icon)
-        print('70:')
         ret = self._safe_create(create)
-        print('ret: {}'.format(ret))
-        print('//73:create_shortcut() %s' % icon)    
         return ret if (ret != 'error') else (shortcut_name, target_path, None)
 
     def _safe_create(self, create):
@@ -406,7 +400,6 @@ class ShortCutter(object):
         :param create:
             function to call (without arguments)
         """
-        print('_safe_create()')
         if self.raise_errors:
             ret = create()
         else:

--- a/shortcutter/base.py
+++ b/shortcutter/base.py
@@ -219,7 +219,7 @@ class ShortCutter(object):
         Returns
         -------
         tuple (str or None, str or None, str or None)
-            (shortcut_name, target_path, shortcut_file_path)
+            (shortcut_name, target_path, shortcut_file_path, icon_file_path)
         """
         print('create_desktop_shortcut() %s' % icon)
         if not p.isdir(self.desktop_folder):
@@ -228,7 +228,7 @@ class ShortCutter(object):
                 raise ShortcutNoDesktopError(msg)
             elif self.error_log is not None:
                 self.error_log.write(msg + '\n')
-                return None, None, None
+                return None, None, None, None
         else:
             return self.create_shortcut(target, self.desktop_folder, shortcut_name, icon)
 

--- a/shortcutter/base.py
+++ b/shortcutter/base.py
@@ -153,7 +153,7 @@ class ShortCutter(object):
             #   `<conda_root>/envs/<local_root_basename>`
             ddot = p.dirname(self.local_root)
             activate = self._check_if_conda_root(p.dirname(ddot))
-            if (p.basename(ddot) == 'envs') and activate:
+            if (p.basename(ddot) == 'envs') and activate: 
                 return activate, p.basename(self.local_root)
 
             # check if we are running pip via `conda env create -f env.yaml`
@@ -180,7 +180,7 @@ class ShortCutter(object):
                 return activate, None
 
         return None, None
-
+     
     def _check_if_conda_root(self, path):
         """
         Checks if provided path is conda root. It should have
@@ -208,7 +208,7 @@ class ShortCutter(object):
         ----------
         target : str
             The target to create a shortcut for, it can be a fully qualified
-            file path ``/path/to/my_program`` or a simple application name
+            file path ``/path/to/my_program`` or a simple application name 
             ``my_program``.
         shortcut_name : str=None
             Name of the shortcut without extension (``.lnk`` would be appended if needed).
@@ -239,7 +239,7 @@ class ShortCutter(object):
         ----------
         target : str
             The target to create a shortcut for, it can be a fully qualified
-            file path ``/path/to/my_program`` or a simple application name
+            file path ``/path/to/my_program`` or a simple application name 
             ``my_program``.
         shortcut_name : str=None
             Name of the shortcut without extension (``.lnk`` would be appended if needed).
@@ -280,10 +280,10 @@ class ShortCutter(object):
     def _create_wrapped_shortcut(self, shortcut_name, target_path, shortcut_directory, activate_args=None, icon=None):
         """
         Creates shell script wrapper for shortcut with activation.
-
+        
         Providing activate_args optional argument switches to creation
         of shortcut to terminal with activated environment.
-
+        
         Returns a tuple of (shortcut_name, target_path, shortcut_file_path)
         """
         if activate_args is None:
@@ -331,7 +331,7 @@ class ShortCutter(object):
         ----------
         target : str
             The target to create a shortcut for, it can be a fully qualified
-            file path ``/path/to/my_program`` or a simple application name
+            file path ``/path/to/my_program`` or a simple application name 
             ``my_program``.
         shortcut_directory : str
             The directory path where the shortcut should be created.
@@ -434,10 +434,6 @@ class ShortCutter(object):
         bool
             True if all operations were successful, False otherwise.
         """
-        # Link shortcuts
-        global linkd
-        linkd={}
-
         activate, env = self.activate_args
         if not activate:
             return
@@ -466,12 +462,6 @@ class ShortCutter(object):
                         ret.append(self._safe_create(
                             lambda: self._create_wrapped_shortcut(name, None, path, (activate, env))
                         ))
-        
-        # link shortcuts dict: {Name: [Link target path, Path to link file]}
-        for i in ret:
-            linkd[i[0]] = [i[1],i[2]]
-        print('--- debug: linkd: %s' % linkd)
-        
         return False if ('error' in ret) else True
 
     # should be overridden
@@ -486,7 +476,7 @@ class ShortCutter(object):
         """
         Recursively creates dirs if they don't exist.
         Utilizes ``self.raise_errors`` and ``self.error_log``.
-
+        
         Parameters
         ----------
         \*args : str
@@ -514,7 +504,7 @@ class ShortCutter(object):
         ----------
         target : str
             The target to find, it can be a fully qualified
-            file path ``/path/to/my_program`` or a simple application name
+            file path ``/path/to/my_program`` or a simple application name 
             ``my_program``.
 
         Returns

--- a/shortcutter/linux.py
+++ b/shortcutter/linux.py
@@ -47,25 +47,31 @@ class ShortCutterLinux(ShortCutter):
         """
         Creates a Linux shortcut file to executable.
         """
+        if not icon:
+            icon='system-file-manager.png'
         return self._create_shortcut_linux(shortcut_name, target_path, shortcut_directory,
                                            '[Desktop Entry]\n' +
                                            'Name={}\n'.format(shortcut_name) +
                                            'Type=Application\n' +
                                            'Path={}\n'.format(target_path) +
                                            'Exec=xdg-open "{}"\n'.format(target_path) +
-                                           'Icon=system-file-manager.png\n',
+                                           'Icon={}\n'.format(icon),
                                            icon=icon)
 
     def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory, icon):
         """
         Creates a Linux shortcut file to folder.
         """
+        if not icon:
+            #icon='system-file-manager.png'
+            icon='utilities-terminal'
         return self._create_shortcut_linux(shortcut_name, target_path, shortcut_directory,
                                            '[Desktop Entry]\n' +
                                            'Name={}\n'.format(shortcut_name) +
                                            'Type=Application\n' +
                                            'Exec="{}" %F\n'.format(target_path) +
-                                           'Terminal=true\n',
+                                           'Terminal=true\n' +
+                                           'Icon={}\n'.format(icon),
                                            icon=icon)
 
     def _create_shortcut_linux(self, shortcut_name, target_path, shortcut_directory, script, icon=None):

--- a/shortcutter/linux.py
+++ b/shortcutter/linux.py
@@ -43,7 +43,7 @@ class ShortCutterLinux(ShortCutter):
         st = os.stat(file_path)
         os.chmod(file_path, st.st_mode | stat.S_IEXEC)
 
-    def _create_shortcut_to_dir(self, shortcut_name, target_path, shortcut_directory):
+    def _create_shortcut_to_dir(self, shortcut_name, target_path, shortcut_directory, icon):
         """
         Creates a Linux shortcut file to executable.
         """
@@ -53,9 +53,10 @@ class ShortCutterLinux(ShortCutter):
                                            'Type=Application\n' +
                                            'Path={}\n'.format(target_path) +
                                            'Exec=xdg-open "{}"\n'.format(target_path) +
-                                           'Icon=system-file-manager.png\n')
+                                           'Icon=system-file-manager.png\n',
+                                           icon=icon)
 
-    def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory):
+    def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory, icon):
         """
         Creates a Linux shortcut file to folder.
         """
@@ -64,9 +65,10 @@ class ShortCutterLinux(ShortCutter):
                                            'Name={}\n'.format(shortcut_name) +
                                            'Type=Application\n' +
                                            'Exec="{}" %F\n'.format(target_path) +
-                                           'Terminal=true\n')
+                                           'Terminal=true\n',
+                                           icon=icon)
 
-    def _create_shortcut_linux(self, shortcut_name, target_path, shortcut_directory, script):
+    def _create_shortcut_linux(self, shortcut_name, target_path, shortcut_directory, script, icon=None):
         """
         Creates a Linux shortcut file using .desktop file script
 

--- a/shortcutter/linux.py
+++ b/shortcutter/linux.py
@@ -43,19 +43,21 @@ class ShortCutterLinux(ShortCutter):
         st = os.stat(file_path)
         os.chmod(file_path, st.st_mode | stat.S_IEXEC)
 
-    def _create_shortcut_to_dir(self, shortcut_name, target_path, shortcut_directory):
+    def _create_shortcut_to_dir(self, shortcut_name, target_path, shortcut_directory, icon=None):
         """
         Creates a Linux shortcut file to executable.
         """
+        if not icon:
+            icon='system-file-manager.png'
         return self._create_shortcut_linux(shortcut_name, target_path, shortcut_directory,
                                            '[Desktop Entry]\n' +
                                            'Name={}\n'.format(shortcut_name) +
                                            'Type=Application\n' +
                                            'Path={}\n'.format(target_path) +
                                            'Exec=xdg-open "{}"\n'.format(target_path) +
-                                           'Icon=system-file-manager.png\n')
+                                           'Icon={}\n',format(icon))
 
-    def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory):
+    def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory, icon):
         """
         Creates a Linux shortcut file to folder.
         """

--- a/shortcutter/linux.py
+++ b/shortcutter/linux.py
@@ -43,21 +43,19 @@ class ShortCutterLinux(ShortCutter):
         st = os.stat(file_path)
         os.chmod(file_path, st.st_mode | stat.S_IEXEC)
 
-    def _create_shortcut_to_dir(self, shortcut_name, target_path, shortcut_directory, icon=None):
+    def _create_shortcut_to_dir(self, shortcut_name, target_path, shortcut_directory):
         """
         Creates a Linux shortcut file to executable.
         """
-        if not icon:
-            icon='system-file-manager.png'
         return self._create_shortcut_linux(shortcut_name, target_path, shortcut_directory,
                                            '[Desktop Entry]\n' +
                                            'Name={}\n'.format(shortcut_name) +
                                            'Type=Application\n' +
                                            'Path={}\n'.format(target_path) +
                                            'Exec=xdg-open "{}"\n'.format(target_path) +
-                                           'Icon={}\n',format(icon))
+                                           'Icon=system-file-manager.png\n')
 
-    def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory, icon):
+    def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory):
         """
         Creates a Linux shortcut file to folder.
         """

--- a/shortcutter/macos.py
+++ b/shortcutter/macos.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 import subprocess as sp
 
 
-def create_shortcut(shortcut_name, target_path, shortcut_directory, script):
+def create_shortcut(shortcut_name, target_path, shortcut_directory, script, icon=None):
     """
     Creates a MacOS app which opens an target_path (executable or folder) using AppleScript script
 
@@ -43,16 +43,17 @@ class ShortCutterMacOS(ShortCutterLinux):
     def _get_menu_folder():
         return p.join('/', 'Applications') 
 
-    def _create_shortcut_to_dir(self, shortcut_name, target_path, shortcut_directory):
+    def _create_shortcut_to_dir(self, shortcut_name, target_path, shortcut_directory, icon):
         """
         Creates a MacOS app which opens a folder via finder
         """
         return create_shortcut(shortcut_name, target_path, shortcut_directory,
                                'tell application "Finder"\n' +
                                'open POSIX file "{}"\n'.format(target_path) +
-                               'end tell\n')
+                               'end tell\n',
+                               icon=icon)
 
-    def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory):
+    def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory, icon):
         """
         Creates a MacOS app which opens an executable via the terminal
         """
@@ -60,4 +61,5 @@ class ShortCutterMacOS(ShortCutterLinux):
                                'tell application "Terminal"\n' +
                                'activate\n' +
                                'do script "{}"\n'.format(target_path) +
-                               'end tell\n')
+                               'end tell\n',
+                               icon=icon)

--- a/shortcutter/windows.py
+++ b/shortcutter/windows.py
@@ -80,10 +80,10 @@ class ShortCutterWindows(ShortCutter):
         pass
 
     def _create_shortcut_to_dir(self, shortcut_name, target_path, shortcut_directory):
-        return self._create_shortcut_win(shortcut_name, target_path, shortcut_directory, True)
+        return self._create_shortcut_win(shortcut_name, target_path, shortcut_directory, icon, True)
 
-    def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory):
-        return self._create_shortcut_win(shortcut_name, target_path, shortcut_directory)
+    def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory, icon):
+        return self._create_shortcut_win(shortcut_name, target_path, shortcut_directory, icon)
 
     def _create_shortcut_win(self, shortcut_name, target_path, shortcut_directory, folder=False, icon=None):
         """
@@ -91,7 +91,7 @@ class ShortCutterWindows(ShortCutter):
 
         Returns tuple (shortcut_name, target_path, shortcut_file_path)
         """
-        icon = r"D:\code-maphew\leo-editor\leo\Icons\LeoApp.ico"
+        print('_create_shortcut_win(): %s' % icon)
         if not folder:
             shortcut_target_path = target_path
             working_directory = p.dirname(target_path)
@@ -121,10 +121,10 @@ class ShortCutterWindows(ShortCutter):
         shortcut.Description = "Shortcut to" + p.basename(target_path)
         if icon:
             shortcut.IconLocation = icon
+            print('//_create_shortcut_win %s' % icon)
         shortcut.save()
 
         return shortcut_name, target_path, shortcut_file_path
-
     def _is_file_the_target(self, target, file_name, file_path):
         match = False
         # does the target have an extension?

--- a/shortcutter/windows.py
+++ b/shortcutter/windows.py
@@ -83,7 +83,8 @@ class ShortCutterWindows(ShortCutter):
         return self._create_shortcut_win(shortcut_name, target_path, shortcut_directory, icon, True)
 
     def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory, icon):
-        return self._create_shortcut_win(shortcut_name, target_path, shortcut_directory, icon)
+        print('_create_shortcut_file(): %s' % icon)
+        return self._create_shortcut_win(shortcut_name, target_path, shortcut_directory, icon=icon)
 
     def _create_shortcut_win(self, shortcut_name, target_path, shortcut_directory, folder=False, icon=None):
         """
@@ -91,7 +92,7 @@ class ShortCutterWindows(ShortCutter):
 
         Returns tuple (shortcut_name, target_path, shortcut_file_path)
         """
-        print('_create_shortcut_win(): %s' % icon)
+        print(f'_create_shortcut_win(): {self}, {shortcut_name}, {target_path}, {shortcut_directory}, {folder}, {icon}')
         if not folder:
             shortcut_target_path = target_path
             working_directory = p.dirname(target_path)

--- a/shortcutter/windows.py
+++ b/shortcutter/windows.py
@@ -85,20 +85,21 @@ class ShortCutterWindows(ShortCutter):
     def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory):
         return self._create_shortcut_win(shortcut_name, target_path, shortcut_directory)
 
-    def _create_shortcut_win(self, shortcut_name, target_path, shortcut_directory, folder=False):
+    def _create_shortcut_win(self, shortcut_name, target_path, shortcut_directory, folder=False, icon=None):
         """
         Creates a Windows shortcut file.
 
         Returns tuple (shortcut_name, target_path, shortcut_file_path)
         """
-        icon = None
+        icon = r"D:\code-maphew\leo-editor\leo\Icons\LeoApp.ico"
         if not folder:
             shortcut_target_path = target_path
             working_directory = p.dirname(target_path)
             ext = p.splitext(target_path)[1].upper()
-            if ext in self._executable_file_extensions:
-                icon = r'%SystemRoot%\System32\imageres.dll,11'
-
+            if not icon:
+                if ext in self._executable_file_extensions:
+                    icon = r'%SystemRoot%\System32\imageres.dll,11'
+        
         elif not p.isdir(target_path):
             # create a bat script that opens the folder:
             

--- a/shortcutter/windows.py
+++ b/shortcutter/windows.py
@@ -79,11 +79,10 @@ class ShortCutterWindows(ShortCutter):
     def _make_executable(file_path):
         pass
 
-    def _create_shortcut_to_dir(self, shortcut_name, target_path, shortcut_directory):
-        return self._create_shortcut_win(shortcut_name, target_path, shortcut_directory, icon, True)
+    def _create_shortcut_to_dir(self, shortcut_name, target_path, shortcut_directory, icon):
+        return self._create_shortcut_win(shortcut_name, target_path, shortcut_directory, True, icon=icon)
 
     def _create_shortcut_file(self, shortcut_name, target_path, shortcut_directory, icon):
-        print('_create_shortcut_file(): %s' % icon)
         return self._create_shortcut_win(shortcut_name, target_path, shortcut_directory, icon=icon)
 
     def _create_shortcut_win(self, shortcut_name, target_path, shortcut_directory, folder=False, icon=None):
@@ -92,7 +91,6 @@ class ShortCutterWindows(ShortCutter):
 
         Returns tuple (shortcut_name, target_path, shortcut_file_path)
         """
-        print(f'_create_shortcut_win(): {self}, {shortcut_name}, {target_path}, {shortcut_directory}, {folder}, {icon}')
         if not folder:
             shortcut_target_path = target_path
             working_directory = p.dirname(target_path)
@@ -109,7 +107,8 @@ class ShortCutterWindows(ShortCutter):
                 f.write(FOLDER_SHORTCUT.format(path=target_path))
             shortcut_target_path = wrapper_path
             working_directory = self.bin_folder_shcut
-            icon = r'%SystemRoot%\explorer.exe,0'
+            if not icon:
+                icon = r'%SystemRoot%\explorer.exe,0'
 
         else:
             shortcut_target_path = target_path
@@ -122,7 +121,6 @@ class ShortCutterWindows(ShortCutter):
         shortcut.Description = "Shortcut to" + p.basename(target_path)
         if icon:
             shortcut.IconLocation = icon
-            print('//_create_shortcut_win %s' % icon)
         shortcut.save()
 
         return shortcut_name, target_path, shortcut_file_path


### PR DESCRIPTION
Works on Linux Mint 18 (so ubuntu) running in a conda env for python 3.6.

In `linux.py` line 67 I used 'utilities-terminal' instead of 'system-file-manager.png' as the default icon. It looks better on my system, and yes the filename extension is not required. However I don't know if this is generic enough for all systems(?)